### PR TITLE
Dockerfileを微修正

### DIFF
--- a/docker/golang/Dockerfile
+++ b/docker/golang/Dockerfile
@@ -11,7 +11,7 @@ WORKDIR /go/src/github.com/sasa-nori/nyaitter
 COPY . .
 
 # go install で /go/bin 配下にバイナリがビルドされる
-RUN GOOS=linux GOARCH=amd64 go build -o ${GOBIN} && go install
+RUN GOOS=linux GOARCH=amd64 go install
 
 # image自体に最初からPATHに/go/binのパスが設定されているため、バイナリファイルを書くだけで動かすことができる
 ENTRYPOINT [ "nyaitter" ]

--- a/docker/golang/Dockerfile
+++ b/docker/golang/Dockerfile
@@ -1,8 +1,8 @@
 # 使用するGolangのイメージを指定する
 FROM golang:1.15.0
 
-ENV GOBIN=/go/bin
-ENV GPPATH=/go
+ENV GOBIN=/go/bin \
+    GOPATH=/go
 
 # ワーキングディレクトリを指定する
 WORKDIR /go/src/github.com/sasa-nori/nyaitter

--- a/docker/golang/Dockerfile
+++ b/docker/golang/Dockerfile
@@ -7,6 +7,10 @@ ENV GOBIN=/go/bin \
 # ワーキングディレクトリを指定する
 WORKDIR /go/src/github.com/sasa-nori/nyaitter
 
+# 依存ライブラリをダウンロード
+COPY go.mod go.sum ./
+RUN go mod download
+
 # book-supplement直下のディレクトリをコンテナ上に載せる
 COPY . .
 

--- a/docker/golang/Dockerfile
+++ b/docker/golang/Dockerfile
@@ -11,7 +11,7 @@ WORKDIR /go/src/github.com/sasa-nori/nyaitter
 COPY . .
 
 # go install で /go/bin 配下にバイナリがビルドされる
-RUN GOOS=linux GOARCH=amd64 go build && go install
+RUN GOOS=linux GOARCH=amd64 go build -o ${GOBIN} && go install
 
 # image自体に最初からPATHに/go/binのパスが設定されているため、バイナリファイルを書くだけで動かすことができる
 ENTRYPOINT [ "nyaitter" ]


### PR DESCRIPTION
## 対応内容
Dockerfileについて、以下の細かい修正を行いました。 🙏 
*ひとまず `docker-compose up` は動いてますが、動作保証完全というわけではありませんので、お手数ですがご確認頂けますと幸いです... 🙇 

- タイポ修正
  - `GPPATH` -> `GOPATH`
- go modを使うようにした
  - go modulesを使ってのDockerfileは go.mod周りのファイルをCOPYした上で `go download` してるのが割と主流っぽかったのでそちらを使いました
- ビルドを簡略化
  - `go install` の際にbuildもしてくれてるっぽいので、そちらに寄せました
    - 他に意図があるようでしたらすみません...
  - また、既存ですと `docker-compose build` 実行時に `go build: build output "nyaitter" already exists and is a directory` となるのですが、こちらの対応で結果的に発生しなくなります
    - go bildつかってエラー無くやる場合には `go build -o ${GOBIN}` でいけるっぽいです
      - 原因はこちら: https://hiro99ma.blogspot.com/2019/11/golanggolang-4.html